### PR TITLE
WIP: Modifying scripts and Dockerfiles to accommodate CA certificates by default

### DIFF
--- a/certs/readme.md
+++ b/certs/readme.md
@@ -3,7 +3,7 @@ Store your entreprise crt in this directory to make them available to any collec
 
 Procedure:
 1. Add your crt in this directory
-2. Add a volume in your docker-compose.override.yml to mount the directory:
+2. Add a volume in your docker-compose.override.yml for each of the applicable collectors to mount the directory:
 ```
 volumes:
   - ./certs:/certs

--- a/collectors/build/jenkins/docker/Dockerfile
+++ b/collectors/build/jenkins/docker/Dockerfile
@@ -13,6 +13,7 @@ WORKDIR /hygieia
 VOLUME ["/hygieia/logs"]
 
 ENV PROP_FILE /hygieia/config/application.properties
+ENV CACERTS /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/cacerts
 
 CMD ./properties-builder.sh && \
   java -jar jenkins-build-collector*.jar --spring.config.location=$PROP_FILE

--- a/collectors/build/jenkins/docker/properties-builder.sh
+++ b/collectors/build/jenkins/docker/properties-builder.sh
@@ -29,6 +29,15 @@ fi
 echo "MONGODB_HOST: $MONGODB_HOST"
 echo "MONGODB_PORT: $MONGODB_PORT"
 
+if [ -d "/certs/" ]; then
+    for f in /certs/*.crt; do
+	  [ -f "$f" ] || break
+	  alias=$(echo $(basename -- "$f") | cut -f 1 -d '.')
+	  keytool -noprompt -storepass changeit -import -alias $alias -keystore ${CACERTS} -file $f
+	  echo "Certificate added: $f"
+	done
+fi
+
 
 #update local host to bridge ip if used for a URL
 DOCKER_LOCALHOST=


### PR DESCRIPTION
Modifying the `properties-builder.sh` scripts and Dockerfiles for collectors to look for CA certificates by default so that when one is working in an enterprise environment with a number of collectors used, the change doesn't have to be made individually across the board. 